### PR TITLE
upgrade required packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-streamlit==0.82.0
-pandas==1.0.5
+streamlit==1.20.0
+pandas==1.5.3
 pickleshare==0.7.5
-scikit-learn==0.24.1
-lightgbm==3.2.1
-pytest==6.0.1
+scikit-learn==1.2.2
+lightgbm==3.3.5
+pytest==7.2.2
 protobuf~=3.19.0


### PR DESCRIPTION
to avoid errors from a deprecation:
- an `AttributeError` was raised due to `np.bool` being deprecated in NumPy 1.20: https://github.com/sowla/grid_stability_app/actions/runs/4487009581/jobs/7890022718#step:5:29
- maybe this is caused by a change in some underlying dependencies, eg. NumPy 1.20.3 is the minimum version required for Pandas 1.5 https://pandas.pydata.org/pandas-docs/version/1.5/getting_started/install.html#dependencies